### PR TITLE
Fix typo in verilator.ts

### DIFF
--- a/src/verilator.ts
+++ b/src/verilator.ts
@@ -229,6 +229,6 @@ export class VerilatorDiagnostics {
     }
 
     public cleanupTmpFiles() {
-        this._tmpDir.removeCallBack();
+        this._tmpDir.removeCallback();
     }
 }


### PR DESCRIPTION
The typo made svlangserver to crash and hang when exiting vim.