### PR TITLE
Support Neovim client with nvim-lspconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The code has been tested to work with below tool versions
 - Sublime Text Build 4126
 - emacs 29.0.50
   * lsp-mode lsp-mode-20220328.1429
+- Neovim 0.7.0
 - Verilator 4.110
 - Icarus Verilog Compiler 10.2
 - Verible v0.0-1114-ged89c1b
@@ -42,6 +43,14 @@ The code has been tested to work with below tool versions
   * Install lsp-mode
   * `npm install -g @imc-trading/svlangserver`
   * Update .emacs/init.el
+- For neovim
+  * Install [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)
+  * `npm install -g @imc-trading/svlangserver`
+  * Add following setting in your init.lua
+  ```lua
+  require'lspconfig'.svlangserver.setup{}
+  ```
+  * Update .nvim/lspconfig.json
 
 To get the snippets, git clone this repo and copy the snippets directory wherever applicable
 
@@ -165,6 +174,25 @@ NOTE: This has been tested with npm version 6.14.13 and node version 14.17.1
                    (lsp-clients-svlangserver-includeIndexing . ("src/**/*.{sv,svh}"))
                    (lsp-clients-svlangserver-excludeIndexing . ("src/test/**/*.{sv,svh}"))))
     ```
+- Example neovim settings file
+    ```json
+    {
+        "languageserver": {
+            "svlangserver": {
+                "command": "svlangserver",
+                "filetypes": ["systemverilog"],
+                "settings": {
+                    "systemverilog.includeIndexing": ["**/*.{sv,svh}"],
+                    "systemverilog.excludeIndexing": ["test/**/*.sv*"],
+                    "systemverilog.defines" : [],
+                    "systemverilog.launchConfiguration": "/tools/verilator -sv -Wall --lint-only",
+                    "systemverilog.formatCommand": "/tools/verible-verilog-format"
+                }
+            }
+        }
+    }
+    ```
+    For project specific settings this file should be at `<WORKSPACE PATH>/.nvim/lspconfig.json`
 
 ## Commands
 * `systemverilog.build_index`: Instructs language server to rerun indexing
@@ -212,6 +240,10 @@ NOTE: This has been tested with npm version 6.14.13 and node version 14.17.1
   * `lsp-clients-svlangserver-build-index` command should rerun the indexing.
   * `lsp-clients-svlangserver-report-hierarchy` command should do the job. If invoked with an active slection, the module name is pre-filled with the selection.
 
+### Neovim usage
+  * `:SvlangserverBuildIndex` command should rerun the indexing.
+  * `:SvlangserverReportHierarchy` command will generate hierarchy file of the word under the cursor in normal mode.
+
 ## Troubleshooting
 - Editor is not able to find language server binary.
     * Make sure the binary is in the system path as exposed to the editor. If the binary is installed in custom directory, expose that path to your editor
@@ -225,7 +257,7 @@ NOTE: This has been tested with npm version 6.14.13 and node version 14.17.1
     * for vscode: Check the SVLangServer output channel
     * for sublime: Open the command palette in the tools menu and select `LSP: Toggle Log Panel`
     * for emacs: Check the `*lsp-log*` buffer
-
+    * for neovim: Add `vim.lsp.set_log_level("info")` in your init.lua then check ~/.cache/nvim/lsp.log
 
 ## Known Issues
 - Language server doesn't understand most verification specific concepts (e.g. classes).

--- a/src/svlangserver.ts
+++ b/src/svlangserver.ts
@@ -113,6 +113,9 @@ connection.onInitialize((params: InitializeParams) => {
         else if (clientName.startsWith("emacs")) {
             svindexer.setClientDir(".emacs");
         }
+        else if (clientName.startsWith("Neovim")) {
+            svindexer.setClientDir(".nvim");
+        }
         else {
             svindexer.setClientDir(".svlangserver");
         }


### PR DESCRIPTION
This commit add the support for Neovim built-in language server. To support various language servers, Neovim developers created [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) to initialize language servers for users. Unlike Coc.nvim, nvim-lspconfig doesn't provide project LSP configuration file. Therefore, I reuse the syntax of `coc-settings.json` and use the json parser to extract the settings of the configuration file.

The only modification of svlangserver is Neovim client detection. I choose `.nvim` as the configuration directory name, and `.nvim/lspconfig.json` as LSP configuration file.

To test the Neovim LSP client, the several things should be setup:

1. Install [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) by any Vim plugin manager.
2. Create `{plugin_root_dir}/nvim-lspconfig/lua/lspconfig/server_configurations/svlangserver.lua` and paste following code.
Note: this step is not required by user after we submit the svlangserver default configuration to nvim-lspconfig.
```lua
local util = require 'lspconfig.util'

local bin_name = 'svlangserver'
local cmd = { bin_name }

if vim.fn.has 'win32' == 1 then
  cmd = { 'cmd.exe', '/C', bin_name }
end
    
local function build_index()
  local params = {
    command = 'systemverilog.build_index',
  }
  vim.lsp.buf.execute_command(params)
end

local function report_hierarchy()
  local params = {
    command = 'systemverilog.report_hierarchy',
    arguments = { vim.fn.expand('<cword>') },
  }
  vim.lsp.buf.execute_command(params)
end

return {
  default_config = {
    cmd = cmd,
    filetypes = { 'verilog', 'systemverilog' },
    root_dir = function(fname)
        return util.root_pattern '.nvim'(fname) or util.find_git_ancestor(fname) or util.path.dirname(fname)
    end,
    single_file_support = true,
    settings = {
      systemverilog = {
        includeIndexing = {"*.{v,vh,sv,svh}","**/*.{v,vh,sv,svh}"},
      },
    },
    on_init = function(client)
      local json = ""
      for line in io.lines(client.config.root_dir .. "/.nvim/lspconfig.json") do
        json = json .. line
      end
      local json = vim.json.decode(json)
      client.config.cmd = {json.languageserver.svlangserver.command}
      client.config.filetypes = json.languageserver.svlangserver.filetypes
      client.config.settings = json.languageserver.svlangserver.settings
    end,
  },
  commands = {
    SvlangserverBuildIndex = {
      build_index,
      description = 'Instructs language server to rerun indexing',
    },
    SvlangserverReportHierarchy = {
      report_hierarchy,
      description = 'Generates hierarchy for the given module',
    },
  },
  docs = {
    description = [[
https://github.com/imc-trading/svlangserver

`svlangserver`, a language server for systemverilog
]],
  },
}
```
3. Create .nvim/lspconfig.json
The syntax is identical to coc-settings.json.
4. Add `require'lspconfig'.svlangserver.setup{}` in `$HOME/.config/nvim/init.lua`.
5. Open any source verilog / systemverilog file of the project folder via Neovim.
6. Enter vim command `:LspInfo`. The LSP should be up now.