### PR TITLE
fix(capabilities): fix checking window/showDocument client capability

### DIFF
--- a/src/svlangserver.ts
+++ b/src/svlangserver.ts
@@ -95,9 +95,9 @@ let svhiercalculator: SystemVerilogHierarchyCalculator = new SystemVerilogHierar
 let settings = default_settings;
 
 connection.onInitialize((params: InitializeParams) => {
-    hasConfigurationCapability = !!(params.capabilities.workspace && !!params.capabilities.workspace.configuration);
-    hasShowWindowCapability = !!(params.capabilities.window && params.capabilities.window.showDocument);
-    clientName = !!params.clientInfo ? params.clientInfo.name : undefined;
+    hasConfigurationCapability = params.capabilities.workspace?.configuration == true;
+    hasShowWindowCapability = params.capabilities.window?.showDocument?.support == true;
+    clientName = params.clientInfo?.name;
 
     try {
         svindexer.setRoot(uriToPath(params.rootUri));


### PR DESCRIPTION
Per the [spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showDocument), the `window.showDocument` is an object: `{ support: boolean }`. This currently causes this LSP server to think that Neovim's LSP client supports `window/showDocument`, when it doesn't.