### PR TITLE
fix(neovim): use default .svlangserver client dir

### DIFF
--- a/src/svlangserver.ts
+++ b/src/svlangserver.ts
@@ -114,9 +114,6 @@ connection.onInitialize((params: InitializeParams) => {
         else if (clientName.toLowerCase().startsWith("emacs")) {
             svindexer.setClientDir(".emacs");
         }
-        else if (clientName.toLowerCase().startsWith("neovim")) {
-            svindexer.setClientDir(".nvim");
-        }
         else {
             svindexer.setClientDir(".svlangserver");
         }


### PR DESCRIPTION
The .nvim/ directory is not an established convention in Neovim, and the
.nvim/ directory setting was recently removed from neovim/lspconfig[1]

[1] https://github.com/neovim/nvim-lspconfig/commit/b99c853099672df4060c4118742edb3217094f9e