### PR TITLE
Fix wrong parsing of port symbol when space between '#('

### DIFF
--- a/src/svcompletion_grammar.ts
+++ b/src/svcompletion_grammar.ts
@@ -817,7 +817,7 @@ export const svcompletion_grammar = {
     ParameterPortList: {
         patterns: [
             {
-                match: r`(#\()`,
+                match: r`(#\s*\()`,
                 tokens: ["operator.hash_open_parantheses.systemverilog"],
                 push: "ParameterPortListBody"
             }
@@ -841,7 +841,7 @@ export const svcompletion_grammar = {
     PortList: {
         patterns: [
             {
-                match: r`((?<!#)\()`,
+                match: r`((?<!#\s*)\()`,
                 tokens: ["operator.open_parantheses.systemverilog"],
                 push: "PortListBody"
             }


### PR DESCRIPTION
Fix wrong parsing of port symbol when parameter-port symbol is not '#(', e.g. some space or newline between '#' and '('.

```
module dummy #    
(
   parameter A=1
) (
   input p0,
   output p2
);

endmodule
```