### PR TITLE
Add scheme to file path for Neovim

### DIFF
--- a/src/svsymbol.ts
+++ b/src/svsymbol.ts
@@ -180,6 +180,9 @@ export class SystemVerilogSymbol {
                 symRange = this.symLocation;
             }
 
+            if (symURI.indexOf("file://") != 0) {
+                symURI = "".concat("file://", symURI);
+            }
             return Location.create(symURI, symRange);
         } catch(error) {
             ConnectionLogger.error(error);


### PR DESCRIPTION
Neovim [asserts](https://github.com/neovim/neovim/blob/6cc6e11929ad76a2dc5204aed95cb9ed1dafde23/runtime/lua/vim/uri.lua#L107) that the file URI must contain a scheme (`file://` prefixes the file path). If the file paths without schemes are used in functions like `goDefinition`, the functions will be failed.

I'm not sure whether the `index.json` containing a file path without a scheme is valid. This provides an easy way to fix the problem.